### PR TITLE
Updated pom.xml to fix unsecure dependency

### DIFF
--- a/eventify-spring-boot/pom.xml
+++ b/eventify-spring-boot/pom.xml
@@ -80,6 +80,12 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
+         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.18.0</version>
+        </dependency>
+
         <!-- mongodb -->
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
org.springdoc.springdoc-openapi-starter-webmvc-ui was vulnerable to CVE-2025-48924 due to org.apache.commons.commons-lang3 dependency version, suggested fix by changing version for org.springframework.boot.commons-lang3